### PR TITLE
Add SmartDCA and hedge guard logic

### DIFF
--- a/src/core/indicators.py
+++ b/src/core/indicators.py
@@ -6,6 +6,9 @@ __all__ = [
     "compute_adx_info",
     "compute_adx",
     "bollinger",
+    "atr",
+    "adx",
+    "rsi",
 ]
 
 
@@ -82,3 +85,67 @@ def bollinger(closes: Sequence[float], period: int, dev: float) -> Tuple[float |
     lower = mean - dev * sd
     upper = mean + dev * sd
     return lower, upper
+
+
+def atr(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], period: int) -> float:
+    """Return the latest ATR value."""
+    if len(closes) < period + 1 or len(highs) < period + 1 or len(lows) < period + 1:
+        return 0.0
+    trs: list[float] = []
+    for i in range(1, len(closes)):
+        tr = max(
+            highs[i] - lows[i],
+            abs(highs[i] - closes[i - 1]),
+            abs(lows[i] - closes[i - 1]),
+        )
+        trs.append(tr)
+    atr_v = sum(trs[:period]) / period
+    for t in trs[period:]:
+        atr_v = (atr_v * (period - 1) + t) / period
+    return atr_v
+
+
+def adx(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], period: int) -> float:
+    """Return the latest ADX value using Wilder smoothing."""
+    if len(closes) < period + 1:
+        return 0.0
+    tr_list: list[float] = []
+    plus_dm_list: list[float] = []
+    minus_dm_list: list[float] = []
+    for i in range(1, len(closes)):
+        up_move = highs[i] - highs[i - 1]
+        down_move = lows[i - 1] - lows[i]
+        plus_dm_list.append(max(up_move if up_move > down_move and up_move > 0 else 0.0, 0.0))
+        minus_dm_list.append(max(down_move if down_move > up_move and down_move > 0 else 0.0, 0.0))
+        tr = max(
+            highs[i] - lows[i],
+            abs(highs[i] - closes[i - 1]),
+            abs(lows[i] - closes[i - 1]),
+        )
+        tr_list.append(tr)
+    atr_val = sum(tr_list[:period])
+    plus_dm = sum(plus_dm_list[:period])
+    minus_dm = sum(minus_dm_list[:period])
+    if atr_val == 0:
+        return 0.0
+    plus_di = 100 * plus_dm / atr_val
+    minus_di = 100 * minus_dm / atr_val
+    di_sum = plus_di + minus_di
+    dx = 0.0 if di_sum == 0 else abs(plus_di - minus_di) / di_sum * 100
+    adx_val = dx
+    for i in range(period, len(tr_list)):
+        atr_val = atr_val - (atr_val / period) + tr_list[i]
+        plus_dm = plus_dm - (plus_dm / period) + plus_dm_list[i]
+        minus_dm = minus_dm - (minus_dm / period) + minus_dm_list[i]
+        plus_di = 100 * plus_dm / atr_val if atr_val else 0.0
+        minus_di = 100 * minus_dm / atr_val if atr_val else 0.0
+        di_sum = plus_di + minus_di
+        dx = 0.0 if di_sum == 0 else abs(plus_di - minus_di) / di_sum * 100
+        adx_val = (adx_val * (period - 1) + dx) / period
+    return adx_val
+
+
+def rsi(closes: Sequence[float], period: int) -> float:
+    """Return the latest RSI value."""
+    val = compute_rsi(closes, period)
+    return 0.0 if val is None else val

--- a/src/strategy/dca.py
+++ b/src/strategy/dca.py
@@ -1,0 +1,59 @@
+from typing import Literal
+from dataclasses import dataclass
+
+@dataclass(slots=True)
+class DCAFilters:
+    adx_max: float = 25.0
+    rsi_exit: int = 60          # LONG: stop DCA if RSI>60 ; SHORT if <40
+    spread_z_max: float = 2.0   # |spread_z| must be ≤ 2
+    vbd_max: float = 0.25       # |vbd| ≤ 0.25
+
+class SmartDCA:
+    MAX_DCA = {"BTCUSDT": 3, "ETHUSDT": 3,
+               "1000PEPEUSDT": 1,
+               "default": 2}
+
+    @staticmethod
+    def calc_step(n: int, atr: float, symbol: str) -> float:
+        """Return ATR-based step distance for the n-th fill (n≥1)."""
+        k = max(1.0, 1.2 * n)
+        if symbol.startswith("1000PEPE"):
+            k *= 1.3
+        return k * atr
+
+    @staticmethod
+    def next_price(base_price: float,
+                   atr: float,
+                   n: int,
+                   symbol: str,
+                   side: Literal["LONG","SHORT"]) -> float:
+        step = SmartDCA.calc_step(n, atr, symbol)
+        return base_price - step if side == "LONG" else base_price + step
+
+    @staticmethod
+    def allowed(n: int,
+                symbol: str,
+                risk_pct_after_fill: float,
+                adx: float,
+                rsi: float,
+                spread_z: float,
+                vbd: float,
+                side: Literal["LONG", "SHORT"] = "LONG",
+                f: DCAFilters = DCAFilters()) -> bool:
+        """True ↦ may place (n+1)-th DCA now."""
+        cap = SmartDCA.MAX_DCA.get(symbol, SmartDCA.MAX_DCA["default"])
+        if n >= cap:
+            return False
+        if risk_pct_after_fill > 5.0:
+            return False
+        if adx >= f.adx_max:
+            return False
+        if abs(spread_z) > f.spread_z_max:
+            return False
+        if abs(vbd) > f.vbd_max:
+            return False
+        if side == "LONG" and rsi > f.rsi_exit and n > 0:
+            return False
+        if side == "SHORT" and rsi < (100 - f.rsi_exit) and n > 0:
+            return False
+        return True

--- a/src/strategy/hedge.py
+++ b/src/strategy/hedge.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from typing import Literal, Tuple
+
+HEDGE_MAP: dict[str, Tuple[str, float]] = {
+    "BTCUSDT": ("ETHUSDT", 0.50),
+    "ETHUSDT": ("BTCUSDT", 0.50),
+    "1000PEPEUSDT": ("BTCUSDT", 0.30),
+    "default": ("BTCUSDT", 0.50),
+}
+
+class HedgeGuard:
+    """Mixin implementing simple hedge logic."""
+
+    hedge_active: bool = False
+    _prev_adx: float = 0.0
+
+    async def maybe_hedge(
+        self,
+        pos,
+        adx_now: float,
+        atr: float,
+        rsi: float,
+    ) -> None:
+        adx_prev = self._prev_adx
+        self._prev_adx = adx_now
+        if (
+            adx_now >= 30 and adx_now > adx_prev and
+            abs(self.unrealised_dd) > 1.5 * atr and
+            ((pos.side == "LONG" and rsi < 20) or (pos.side == "SHORT" and rsi > 80)) and
+            not self.hedge_active
+        ):
+            hedge_sym, ratio = HEDGE_MAP.get(pos.symbol, HEDGE_MAP["default"])
+            qty = pos.notional_value * ratio / self._last_price(hedge_sym)
+            side = "SHORT" if pos.side == "LONG" else "LONG"
+            await self._open_hedge(hedge_sym, qty, side)
+            self.hedge_active = True
+
+        if self.hedge_active:
+            pnl = self._hedge_pnl()
+            if (
+                pnl >= atr * 1 or
+                adx_now < 25 or
+                (pos.side == "LONG" and rsi > 25) or
+                (pos.side == "SHORT" and rsi < 75)
+            ):
+                await self._close_hedge()
+                self.hedge_active = False

--- a/tests/test_hedge.py
+++ b/tests/test_hedge.py
@@ -1,0 +1,41 @@
+import asyncio
+from types import SimpleNamespace
+
+from src.strategy.hedge import HEDGE_MAP, HedgeGuard
+
+
+def test_mapping():
+    assert HEDGE_MAP["BTCUSDT"][0] == "ETHUSDT"
+    assert HEDGE_MAP.get("DOGEUSDT", HEDGE_MAP["default"])[0] == "BTCUSDT"
+
+
+class Dummy(HedgeGuard):
+    def __init__(self):
+        self.unrealised_dd = 0.0
+        self.opened = False
+        self.closed = False
+
+    def _last_price(self, symbol: str) -> float:
+        return 1.0
+
+    async def _open_hedge(self, sym: str, qty: float, side: str) -> None:
+        self.opened = True
+        self.open_args = (sym, qty, side)
+
+    async def _close_hedge(self) -> None:
+        self.closed = True
+
+    def _hedge_pnl(self) -> float:
+        return self.pnl
+
+
+def test_trigger_open_and_close():
+    d = Dummy()
+    pos = SimpleNamespace(symbol="BTCUSDT", side="LONG", notional_value=100)
+    d.unrealised_dd = 2.0
+    d.pnl = 0.0
+    asyncio.run(d.maybe_hedge(pos, adx_now=31, atr=1, rsi=10))
+    assert d.opened and d.hedge_active
+    d.pnl = 1.1
+    asyncio.run(d.maybe_hedge(pos, adx_now=24, atr=1, rsi=10))
+    assert d.closed and not d.hedge_active

--- a/tests/test_smart_dca.py
+++ b/tests/test_smart_dca.py
@@ -1,0 +1,9 @@
+def test_filters_block():
+    from src.strategy.dca import SmartDCA
+    assert not SmartDCA.allowed(0, "BTCUSDT", 4.0, adx=27, rsi=30, spread_z=1, vbd=0.1)
+
+def test_cap():
+    from src.strategy.dca import SmartDCA
+    for n in range(3):
+        assert SmartDCA.allowed(n, "ETHUSDT", 1, adx=10, rsi=25, spread_z=0, vbd=0)
+    assert not SmartDCA.allowed(3, "ETHUSDT", 1, adx=10, rsi=25, spread_z=0, vbd=0)


### PR DESCRIPTION
## Summary
- implement ATR-based SmartDCA with per-symbol caps
- expose atr/adx/rsi helpers in indicators
- add HedgeGuard with mapping and trigger logic
- unit tests for SmartDCA and HedgeGuard

## Testing
- `pytest -q`