### PR TITLE
Add backtesting support and core tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,5 @@ jobs:
           python-version: '3.11'
       - run: pip install -r requirements.txt
       - run: pip install pytest
-      - run: pytest -q
+      - name: Run tests
+        run: pytest -q

--- a/app/backtest.py
+++ b/app/backtest.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from collections import deque
+
+from src.core.data import Bar
+from src.core import indicators
+from src.strategy.entry import BounceEntry, EntrySignal
+from src.strategy.manager import PositionManager
+
+
+class BacktestEngine:
+    """Offline backtesting wrapper for :class:`SymbolEngine`."""
+
+    def __init__(self, symbol: str, equity: float = 10000.0, log_equity: bool = False) -> None:
+        self.symbol = symbol
+        self.start_equity = equity
+        self.equity = equity
+        self.log_equity = log_equity
+        self.equity_curve: list[tuple[int, float]] = []
+
+        self.position = PositionManager()
+        self.highs: deque[float] = deque(maxlen=50)
+        self.lows: deque[float] = deque(maxlen=50)
+        self.closes: deque[float] = deque(maxlen=50)
+        self.volumes: deque[float] = deque(maxlen=20)
+        self.close_window: deque[float] = deque(maxlen=30)
+        self.trades = 0
+        self.wins = 0
+
+    # ------------------------------------------------------------------
+    async def feed_bar(self, open_: float, high: float, low: float, close: float, volume: float, ts: int) -> None:
+        bar = Bar(open_, high, low, close, volume, ts, ts + 300)
+        await self.on_bar(bar)
+
+    async def on_bar(self, bar: Bar) -> None:
+        self.highs.append(bar.high)
+        self.lows.append(bar.low)
+        self.closes.append(bar.close)
+        self.volumes.append(bar.volume)
+        self.close_window.append(bar.close)
+
+        atr_v = indicators.atr(list(self.highs), list(self.lows), list(self.closes), 14)
+
+        signal = BounceEntry.check(bar, self.volumes, self.close_window, {})
+        if self.position.state.qty == 0 and signal is not None:
+            side = signal.value
+            self.position.open(side, qty=1, entry=bar.close, atr=atr_v or 1)
+            self.trades += 1
+            return
+
+        if self.position.state.qty > 0:
+            result = self.position.on_tick(bar.close)
+            if result in {"SL", "TRAIL"}:
+                pnl = (bar.close - self.position.state.entry)
+                if self.position.state.side == "SHORT":
+                    pnl = -pnl
+                pnl *= self.position.initial_qty
+                self.equity += pnl
+                if pnl > 0:
+                    self.wins += 1
+            elif result in {"TP1", "TP2"}:
+                pnl = (bar.close - self.position.state.entry)
+                if self.position.state.side == "SHORT":
+                    pnl = -pnl
+                pnl *= self.position.closed_qty
+                self.equity += pnl
+
+        if self.log_equity:
+            self.equity_curve.append((bar.start, self.equity))
+
+    # ------------------------------------------------------------------
+    def save_equity_csv(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            for ts, eq in self.equity_curve:
+                f.write(f"{ts},{eq}\n")
+
+    def summary(self) -> dict:
+        win_rate = (self.wins / self.trades * 100) if self.trades else 0.0
+        return {
+            "symbol": self.symbol,
+            "trades": self.trades,
+            "win_rate": win_rate,
+            "day_pnl": self.equity - self.start_equity,
+        }
+

--- a/scripts/backtest_day.py
+++ b/scripts/backtest_day.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Run:  python scripts/backtest_day.py --symbol BTCUSDT --date 2025-05-15 \
+      --csv data/BTCUSDT_2025-05-15_kline5m.csv --equity 10000
+"""
+import argparse
+import csv
+import asyncio
+import json
+import pathlib
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.backtest import BacktestEngine
+
+
+def load_bars(path: str):
+    with open(path) as f:
+        for ts, o, h, l, c, v in csv.reader(f):
+            yield float(o), float(h), float(l), float(c), float(v), int(ts)
+
+
+async def main(args) -> None:
+    engine = BacktestEngine(symbol=args.symbol, equity=args.equity, log_equity=True)
+    for row in load_bars(args.csv):
+        await engine.feed_bar(*row)
+    equity_path = pathlib.Path("backtests") / f"{args.symbol}_{args.date}_equity.csv"
+    engine.save_equity_csv(equity_path)
+    summary = engine.summary()
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--symbol", required=True)
+    p.add_argument("--date", required=True)
+    p.add_argument("--csv", required=True)
+    p.add_argument("--equity", type=float, default=10000)
+    asyncio.run(main(p.parse_args()))

--- a/src/strategy/manager.py
+++ b/src/strategy/manager.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+"""Simple position management for backtesting."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PositionState:
+    side: str | None = None
+    qty: float = 0.0
+    entry: float = 0.0
+    atr: float = 0.0
+
+
+class PositionManager:
+    """Handle partial take profits and trailing stop logic."""
+
+    def __init__(
+        self,
+        tp1_ratio: float = 0.4,
+        tp2_ratio: float = 0.3,
+        sl_atr: float = 1.5,
+        tp1_atr: float = 1.0,
+        tp2_atr: float = 2.0,
+        trailing_pct: float = 0.2,
+    ) -> None:
+        self.tp1_ratio = tp1_ratio
+        self.tp2_ratio = tp2_ratio
+        self.sl_atr = sl_atr
+        self.tp1_atr = tp1_atr
+        self.tp2_atr = tp2_atr
+        self.trailing_pct = trailing_pct
+        self.state = PositionState()
+        self.initial_qty = 0.0
+        self.sl: float | None = None
+        self.tp1: float | None = None
+        self.tp2: float | None = None
+        self.closed_qty = 0.0
+        self.trailing_started = False
+        self.best_price: float | None = None
+        self.trail_price: float | None = None
+
+    # ------------------------------------------------------------------
+    def open(self, side: str, qty: float, entry: float, atr: float) -> None:
+        """Open a new position and set TP/SL levels."""
+        self.state.side = side
+        self.state.qty = qty
+        self.initial_qty = qty
+        self.state.entry = entry
+        self.state.atr = atr
+        if side == "LONG":
+            self.sl = entry - self.sl_atr * atr
+            self.tp1 = entry + self.tp1_atr * atr
+            self.tp2 = entry + self.tp2_atr * atr
+        else:
+            self.sl = entry + self.sl_atr * atr
+            self.tp1 = entry - self.tp1_atr * atr
+            self.tp2 = entry - self.tp2_atr * atr
+        self.closed_qty = 0.0
+        self.trailing_started = False
+        self.best_price = entry
+        self.trail_price = entry
+
+    # ------------------------------------------------------------------
+    def _close_fraction(self, frac: float) -> float:
+        qty_close = min(self.state.qty, self.initial_qty * frac)
+        self.state.qty -= qty_close
+        self.closed_qty += qty_close
+        return qty_close
+
+    # ------------------------------------------------------------------
+    def on_tick(self, price: float) -> str | None:
+        """Update position state based on ``price``."""
+        if self.state.side is None or self.state.qty <= 0:
+            return None
+        side = self.state.side
+
+        # stop-loss -----------------------------------------------------
+        if side == "LONG" and self.sl is not None and price <= self.sl:
+            self._close_fraction(1.0)
+            self.state.side = None
+            return "SL"
+        if side == "SHORT" and self.sl is not None and price >= self.sl:
+            self._close_fraction(1.0)
+            self.state.side = None
+            return "SL"
+
+        # TP1 -----------------------------------------------------------
+        if not self.trailing_started:
+            if side == "LONG" and self.tp1 is not None and price >= self.tp1:
+                self._close_fraction(self.tp1_ratio)
+                self.trailing_started = True
+                self.best_price = price
+                self.trail_price = self.state.entry
+                return "TP1"
+            if side == "SHORT" and self.tp1 is not None and price <= self.tp1:
+                self._close_fraction(self.tp1_ratio)
+                self.trailing_started = True
+                self.best_price = price
+                self.trail_price = self.state.entry
+                return "TP1"
+
+        # TP2 -----------------------------------------------------------
+        if self.trailing_started and self.state.qty > 0:
+            if side == "LONG" and self.tp2 is not None and price >= self.tp2:
+                self._close_fraction(self.tp2_ratio)
+                self.best_price = price
+                return "TP2"
+            if side == "SHORT" and self.tp2 is not None and price <= self.tp2:
+                self._close_fraction(self.tp2_ratio)
+                self.best_price = price
+                return "TP2"
+
+        # trailing ------------------------------------------------------
+        if self.trailing_started and self.state.qty > 0:
+            if side == "LONG":
+                if price > (self.best_price or price):
+                    self.best_price = price
+                    self.trail_price = price * (1 - self.trailing_pct / 100)
+                if self.trail_price is not None and price <= self.trail_price:
+                    self._close_fraction(1.0)
+                    self.state.side = None
+                    return "TRAIL"
+            else:  # SHORT
+                if price < (self.best_price or price):
+                    self.best_price = price
+                    self.trail_price = price * (1 + self.trailing_pct / 100)
+                if self.trail_price is not None and price >= self.trail_price:
+                    self._close_fraction(1.0)
+                    self.state.side = None
+                    return "TRAIL"
+
+        return None

--- a/tests/tests_indicators_entry_manager.py
+++ b/tests/tests_indicators_entry_manager.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+from collections import deque, namedtuple
+
+from src.core import indicators
+from src.strategy.entry import BounceEntry, EntrySignal
+from src.strategy.manager import PositionManager
+
+Bar = namedtuple("Bar", "open high low close volume start end")
+
+
+@pytest.fixture
+def ohlc_20():
+    high = np.array([11,12,13,14,15,14,13,12,11,10,
+                     11,12,13,14,15,14,13,12,11,10], dtype=float)
+    low  = high - 1.5
+    close= (high+low)/2
+    return high, low, close
+
+
+@pytest.fixture
+def bar_extreme():
+    # pin-bar touching lower BB, volume ×3
+    return Bar(10,10.05,9.5,9.6, 300, 0,0)
+
+# ---------- ATR ---------- #
+def test_atr_known(ohlc_20):
+    h,l,c = ohlc_20
+    atr = indicators.atr(h,l,c,period=14)
+    assert round(float(atr),4) == 1.5   # constant range → ATR == range
+
+# ---------- ENTRY ---------- #
+def test_bounce_long(bar_extreme):
+    closes = deque([10]*30, maxlen=30)
+    vols   = deque([100]*19+[300], maxlen=20)
+    sig = BounceEntry.check(bar_extreme, vols, closes, params={})
+    assert sig is EntrySignal.LONG
+
+def test_bounce_none_due_rsi():
+    closes = deque([i for i in range(60)], maxlen=60)  # trending ⇒ RSI high
+    bar    = Bar(59,60,58,59.9,150,0,0)
+    sig = BounceEntry.check(bar, deque([120]*20), closes, {})
+    assert sig is None
+
+# ---------- MANAGER ---------- #
+def test_tp1_hit():
+    pm = PositionManager()
+    pm.open(side="LONG", qty=1, entry=100, atr=2)      # SL 1.5 ATR, TP1 1 ATR
+    assert pm.tp1 == 102
+    pm.on_tick(price=102.1)
+    assert pm.closed_qty == pytest.approx(0.4, rel=1e-2)
+    assert pm.trailing_started
+
+def test_tp2_and_trailing():
+    pm = PositionManager()
+    pm.open(side="LONG", qty=1, entry=100, atr=2)
+    pm.on_tick(102.1)  # TP1
+    pm.on_tick(104.1)  # TP2
+    assert pm.closed_qty == pytest.approx(0.7, rel=1e-2)
+    pm.on_tick(105.0)  # move best price
+    trail = pm.trail_price
+    assert trail and trail > 0
+    pm.on_tick(trail - 0.01)
+    assert pm.state.qty == 0


### PR DESCRIPTION
## Summary
- add simple position manager for backtests
- provide pytest coverage for indicators, entry and manager logic
- implement BacktestEngine and CLI tool
- name step in CI workflow

## Testing
- `pytest -q`
- `python scripts/backtest_day.py --symbol BTCUSDT --date 2025-01-01 --csv sample.csv --equity 10000`