### PR TITLE
Fix requirements syntax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pydantic==2.*
 pydantic-settings>=2.9.1,<3
 pybit>=5.10.1
 aiosqlite
-numpy>=1.25.*
+numpy>=1.25
 pytest-asyncio==0.23


### PR DESCRIPTION
## Summary
- correct `numpy` version constraint in `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp==3.9.*)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*