### PR TITLE
Fix pytest_asyncio version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydantic==2.*
 pydantic-settings>=2.9.1,<3
 pybit>=5.10.1
 aiosqlite
-pytest-asyncio==0.23
+pytest-asyncio==0.23.6


### PR DESCRIPTION
## Summary
- update `pytest-asyncio` to 0.23.6 to avoid compatibility issues with newer pytest versions

## Testing
- `pytest -q`