### PR TITLE
Add setting to disable placing orders

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class BybitSettings(BaseModel):
     symbols: list[str]
     testnet: bool = False
     demo: bool = False
+    place_orders: bool = True
     channel_type: str = "linear"
 
 class TradingSettings(BaseModel):

--- a/app/risk.py
+++ b/app/risk.py
@@ -164,6 +164,7 @@ class RiskManager:
                             settings.bybit.testnet,
                             settings.bybit.demo,
                             settings.bybit.channel_type,
+                            settings.bybit.place_orders,
                         )
                         self._htf_client = client
                     resp = client.http.get_kline(

--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -99,6 +99,7 @@ class SymbolEngine:
             testnet=settings.bybit.testnet,
             demo=settings.bybit.demo,
             channel_type=settings.bybit.channel_type,
+            place_orders=settings.bybit.place_orders,
         )
         self.client.set_leverage(self.symbol, lev)
 

--- a/settings.toml
+++ b/settings.toml
@@ -8,6 +8,7 @@ api_key       = "zf72Bea3s8kMDd031d"          # ← замените при не
 api_secret    = "XMfDkNDUNRXWbSAkkSY5Prvz59lWaWIIzgw5"
 testnet       = false
 demo          = true
+place_orders  = false
 channel_type  = "linear"
 symbols       = [
   "BTCUSDT","ETHUSDT","SOLUSDT","DOGEUSDT",


### PR DESCRIPTION
## Summary
- add `place_orders` option to Bybit settings
- implement checks in exchange client to skip order related API calls
- wire new option into symbol engine and risk module
- default to disabled in settings

## Testing
- `pytest -q`