### PR TITLE
Fix Bollinger output handling

### DIFF
--- a/src/strategy/entry.py
+++ b/src/strategy/entry.py
@@ -60,10 +60,10 @@ class BounceEntry:
             return None
 
         closes_seq: list[float] = list(closes)
-        lower, upper = bollinger(closes_seq, cfg["bb_period"], cfg["bb_dev"])
+        lower, _, upper = bollinger(closes_seq, cfg["bb_period"], cfg["bb_dev"])
         if lower is None or upper is None:
             return None
-        if bar.close >= lower:
+        if bar.close <= lower:
             direction = EntrySignal.LONG
         elif bar.close >= upper:
             direction = EntrySignal.SHORT


### PR DESCRIPTION
## Summary
- fix `BounceEntry.check` to correctly unpack Bollinger values and identify trade direction

## Testing
- `pytest -q`
- `python scripts/backtest_year.py --symbols BTCUSDT,ETHUSDT --year 2025 --data-dir data --equity 10000 --out-dir backtests`