### PR TITLE
Add batch downloader & orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # hft
+
+## Backtesting
+
+Several helper scripts for offline backtesting are located in the `scripts` 
+directory. They expect candle data in CSV format (for example
+`BTCUSDT_2025-05_kline5m.csv`) stored in the directory specified by
+`--data-dir`.
+
+### Daily backtest
+
+```bash
+python scripts/backtest_day.py --symbol BTCUSDT --date 2025-05-15 \
+  --csv data/BTCUSDT_2025-05-15_kline5m.csv --equity 10000
+```
+
+### Monthly backtest
+
+```bash
+python scripts/backtest_month.py --symbols BTCUSDT,ETHUSDT --month 2025-05 \
+  --data-dir data --equity 10000 --out-dir backtests
+```
+
+This command writes equity curves for each symbol to `backtests/` and saves a
+summary JSON file `summary_2025-05.json`.
+
+### Yearly backtest
+
+```bash
+python scripts/backtest_year.py --symbols BTCUSDT,ETHUSDT --year 2025 \
+  --data-dir data --equity 10000 --out-dir backtests
+```
+
+After completion all monthly equity CSV files and a yearly summary JSON will be
+available in the output directory. These CSV files can be combined or analysed
+in any spreadsheet application or with `pandas` for further research.
+
+### Full-year one-liner
+
+```bash
+python scripts/fetch_and_backtest_year.py --year 2025 --interval 5 --equity 10000
+```
+
+Downloads all pairs listed in `[bybit].symbols`.
+
+Produces `backtests/summary_2025.json` and monthly equity CSVs.

--- a/scripts/backtest_year.py
+++ b/scripts/backtest_year.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Run:
+  python scripts/backtest_year.py --symbols BTCUSDT,ETHUSDT --year 2025 \
+    --data-dir data --equity 10000 --out-dir backtests
+"""
+import argparse
+import asyncio
+import csv
+import json
+import os
+import pathlib
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.backtest import BacktestEngine
+from helpers.metrics import sharpe, profit_factor, max_drawdown
+
+
+def load_bars(path: str):
+    with open(path) as f:
+        for ts, o, h, l, c, v in csv.reader(f):
+            yield float(o), float(h), float(l), float(c), float(v), int(ts)
+
+
+async def backtest(
+    symbol: str, csv_path: pathlib.Path, period: str, equity: float, out_dir: pathlib.Path
+) -> dict:
+    engine = BacktestEngine(symbol=symbol, equity=equity, log_equity=True)
+    for row in load_bars(str(csv_path)):
+        await engine.feed_bar(*row)
+    engine.save_equity_csv(out_dir / f"{symbol}_{period}_equity.csv")
+    equity_vals = [eq for _, eq in engine.equity_curve]
+    returns = [equity_vals[i + 1] - equity_vals[i] for i in range(len(equity_vals) - 1)]
+    return {
+        "symbol": symbol,
+        "trades": engine.trades,
+        "pnl": equity_vals[-1] - equity_vals[0] if equity_vals else 0.0,
+        "sharpe": sharpe(equity_vals),
+        "pf": profit_factor([{"pnl": r} for r in returns]),
+        "dd": max_drawdown(equity_vals),
+        "returns": returns,
+    }
+
+
+async def main(args) -> None:
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    out_dir = pathlib.Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    all_results = []
+    aggregate_returns = []
+    for month in range(1, 13):
+        period = f"{args.year}-{month:02d}"
+        for sym in symbols:
+            csv_file = pathlib.Path(args.data_dir) / f"{sym}_{period}_kline5m.csv"
+            if not csv_file.exists():
+                continue
+            res = await backtest(sym, csv_file, period, args.equity, out_dir)
+            all_results.append(res)
+            aggregate_returns.extend(res["returns"])
+            print(
+                f"{sym} {period} trades={res['trades']} pnl={res['pnl']:.2f} "
+                f"sharpe={res['sharpe']:.2f} pf={res['pf']:.2f} dd={res['dd']:.2f}"
+            )
+
+    agg_equity = [0.0]
+    for r in aggregate_returns:
+        agg_equity.append(agg_equity[-1] + r)
+    aggregate = {
+        "trades": sum(r["trades"] for r in all_results),
+        "pnl": agg_equity[-1],
+        "sharpe": sharpe(agg_equity),
+        "pf": profit_factor([{"pnl": r} for r in aggregate_returns]),
+        "dd": max_drawdown(agg_equity),
+    }
+    print(
+        f"YEAR trades={aggregate['trades']} pnl={aggregate['pnl']:.2f} "
+        f"sharpe={aggregate['sharpe']:.2f} pf={aggregate['pf']:.2f} "
+        f"dd={aggregate['dd']:.2f}"
+    )
+    summary_path = out_dir / f"summary_{args.year}.json"
+    with open(summary_path, "w") as f:
+        json.dump({"symbols": all_results, "aggregate": aggregate}, f, indent=2)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--symbols", required=True)
+    p.add_argument("--year", type=int, required=True)
+    p.add_argument("--data-dir", default="data")
+    p.add_argument("--equity", type=float, default=10000)
+    p.add_argument("--out-dir", default="backtests")
+    asyncio.run(main(p.parse_args()))

--- a/scripts/fetch_and_backtest_year.py
+++ b/scripts/fetch_and_backtest_year.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+One-shot: download all 5-minute data for given year & symbols, then run
+scripts/backtest_year.py and print KPI table.
+"""
+import argparse, subprocess, sys, json, pathlib, tomllib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DL   = [sys.executable, "-m", "utils.download_klines"]
+BT   = [sys.executable, "scripts/backtest_year.py"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--year", type=int, required=True)
+    ap.add_argument("--symbols", help="CSV list; default = [bybit].symbols")
+    ap.add_argument("--interval", type=int, default=5)
+    ap.add_argument("--equity", type=float, default=10_000)
+    ap.add_argument("--data-dir", default="data")
+    ap.add_argument("--out-dir",  default="backtests")
+    args = ap.parse_args()
+
+    if args.symbols:
+        syms = [s.strip() for s in args.symbols.split(",")]
+    else:
+        with open(ROOT/"settings.toml", "rb") as f:
+            syms = tomllib.load(f)["bybit"]["symbols"]
+
+    # 1. download
+    for s in syms:
+        cmd = DL + ["--symbol", s, "--year", str(args.year),
+                    "--interval", str(args.interval),
+                    "--data-dir", args.data_dir]
+        subprocess.run(cmd, check=True)
+
+    # 2. backtest
+    bt_cmd = BT + ["--symbols", ",".join(syms),
+                   "--year", str(args.year),
+                   "--data-dir", args.data_dir,
+                   "--equity", str(args.equity),
+                   "--out-dir", args.out_dir]
+    subprocess.run(bt_cmd, check=True)
+
+    # 3. pretty-print summary JSON
+    summ = pathlib.Path(args.out_dir)/f"summary_{args.year}.json"
+    print(json.dumps(json.loads(summ.read_text()), indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_download_cli.py
+++ b/tests/test_download_cli.py
@@ -1,0 +1,43 @@
+import runpy
+import sys
+import types
+
+
+def test_download_cli(tmp_path, monkeypatch):
+    class DummyHTTP:
+        def __init__(self, *a, **k):
+            self.called = False
+
+        def get_kline(self, **params):
+            if self.called:
+                return {"result": {"list": []}}
+            self.called = True
+            return {
+                "result": {
+                    "list": [
+                        {
+                            "start": params["start"],
+                            "open": "1",
+                            "high": "1",
+                            "low": "1",
+                            "close": "1",
+                            "volume": "1",
+                        }
+                    ]
+                }
+            }
+
+    dummy_mod = types.SimpleNamespace(HTTP=DummyHTTP)
+    monkeypatch.setitem(sys.modules, "pybit.unified_trading", dummy_mod)
+    monkeypatch.setitem(sys.modules, "requests", types.SimpleNamespace(
+        ReadTimeout=Exception, ConnectionError=Exception
+    ))
+    monkeypatch.setitem(sys.modules, "urllib3", types.SimpleNamespace(exceptions=types.SimpleNamespace(ProtocolError=Exception)))
+    monkeypatch.setattr(sys, "argv", [
+        "utils.download_klines",
+        "--symbol", "BTCUSDT",
+        "--month", "2025-01",
+        "--data-dir", str(tmp_path),
+    ])
+    runpy.run_module("utils.download_klines", run_name="__main__")
+    assert (tmp_path / "BTCUSDT_2025-01_kline5m.csv").exists()

--- a/utils/download_klines.py
+++ b/utils/download_klines.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Download historical 5-minute klines from Bybit.
+
+Examples
+--------
+Download one month of BTCUSDT data::
+
+    python -m utils.download_klines --symbol BTCUSDT --month 2025-05
+
+Download an entire year (creates 12 monthly CSV files)::
+
+    python -m utils.download_klines --symbol BTCUSDT --year 2025
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import pathlib
+import time
+import tomllib
+
+from pybit.unified_trading import HTTP
+
+from utils.retry import retry_rest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@retry_rest()
+def _get_klines(http: HTTP, **params):
+    """Wrapper around ``HTTP.get_kline`` with retries."""
+    return http.get_kline(**params)
+
+
+def collect(
+    symbol: str,
+    month: str,
+    data_dir: pathlib.Path,
+    http: HTTP | None = None,
+    *,
+    interval: int = 5,
+) -> pathlib.Path:
+    """Download one month of klines and save to CSV.
+
+    Parameters
+    ----------
+    symbol:
+        Trading pair, e.g. ``"BTCUSDT"``.
+    month:
+        Month in ``YYYY-MM`` format.
+    data_dir:
+        Directory where CSV files are written.
+    http:
+        Existing :class:`HTTP` client instance. If ``None``, a new one will be created.
+
+    Returns
+    -------
+    :class:`pathlib.Path`
+        Path to the written CSV file.
+    """
+
+    if http is None:
+        http = HTTP(timeout=30)
+
+    start_dt = dt.datetime.strptime(month + "-01", "%Y-%m-%d")
+    next_month = (start_dt.replace(day=28) + dt.timedelta(days=4)).replace(day=1)
+    end_ms = int(next_month.timestamp() * 1000)
+    cur = int(start_dt.timestamp() * 1000)
+    out_path = data_dir / f"{symbol}_{month}_kline{interval}m.csv"
+    if out_path.exists():
+        print(f"exists: {out_path}")
+        return out_path
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(out_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        while cur < end_ms:
+            resp = _get_klines(
+                http,
+                category="linear",
+                symbol=symbol,
+                interval=str(interval),
+                start=cur,
+                end=end_ms,
+                limit=200,
+            )
+            klines = resp.get("result", {}).get("list", [])
+            if not klines:
+                break
+            # API may return lists instead of dicts; convert for convenience
+            if klines and isinstance(klines[0], list):
+                keys = [
+                    "start",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "turnover",
+                ]
+                klines = [dict(zip(keys, k)) for k in klines]
+            klines.sort(key=lambda x: int(x.get("start") or x.get("t")))
+            for k in klines:
+                writer.writerow(
+                    [
+                        int(k.get("start") or k.get("t")),
+                        k.get("open") or k.get("o"),
+                        k.get("high") or k.get("h"),
+                        k.get("low") or k.get("l"),
+                        k.get("close") or k.get("c"),
+                        k.get("volume") or k.get("v"),
+                    ]
+                )
+            cur = int(klines[-1].get("start") or klines[-1].get("t")) + interval * 60 * 1000
+            time.sleep(0.1)
+
+    return out_path
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Download Bybit kline data")
+    sym = p.add_mutually_exclusive_group(required=True)
+    sym.add_argument("--symbol", help="Trading pair, e.g. BTCUSDT")
+    sym.add_argument("--symbols", help="Comma-separated trading pairs")
+    sym.add_argument(
+        "--all",
+        action="store_true",
+        help="Use symbols list from settings.toml",
+    )
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument("--month", help="Month YYYY-MM to download")
+    group.add_argument("--start", help="Download from YYYY-MM-DD until today")
+    group.add_argument("--year", type=int, help="Download all months of given year")
+    p.add_argument("--interval", type=int, default=5, help="Kline interval in minutes")
+    p.add_argument("--data-dir", default="data", help="Directory for CSV files")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    data_dir = pathlib.Path(args.data_dir)
+    http = HTTP(timeout=30)
+
+    if args.symbol:
+        symbols = [args.symbol]
+    elif args.symbols:
+        symbols = [s.strip() for s in args.symbols.split(',') if s.strip()]
+    else:
+        with open(ROOT / "settings.toml", "rb") as f:
+            symbols = tomllib.load(f)["bybit"]["symbols"]
+
+    if args.year:
+        for m in range(1, 13):
+            month = f"{args.year}-{m:02d}"
+            for sym in symbols:
+                print(f"Downloading {sym} {month}…")
+                collect(sym, month, data_dir, http, interval=args.interval)
+        return
+
+    if args.month:
+        for sym in symbols:
+            collect(sym, args.month, data_dir, http, interval=args.interval)
+        return
+
+    # --start logic: download starting from given date up to today
+    start = dt.datetime.strptime(args.start, "%Y-%m-%d")
+    today = dt.datetime.utcnow().replace(day=1)
+    while start < today:
+        month = start.strftime("%Y-%m")
+        for sym in symbols:
+            print(f"Downloading {sym} {month}…")
+            collect(sym, month, data_dir, http, interval=args.interval)
+        # move to next month
+        start = (start.replace(day=28) + dt.timedelta(days=4)).replace(day=1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restore `download_klines.py` and `backtest_year.py`
- extend downloader with multi-symbol support and `--interval`
- add `fetch_and_backtest_year.py` helper
- document full‑year one-liner
- test downloader CLI

## Testing
- `pytest -q`