### PR TITLE
Integrate entry+DCA+exit in SymbolEngine

### DIFF
--- a/src/strategy/manager.py
+++ b/src/strategy/manager.py
@@ -63,6 +63,24 @@ class PositionManager:
         self.trail_price = entry
 
     # ------------------------------------------------------------------
+    def add(self, qty: float, price: float) -> None:
+        """Increase position size and recalc average entry price."""
+        if self.state.side is None or qty <= 0:
+            return
+        total = self.state.entry * self.state.qty + price * qty
+        self.state.qty += qty
+        self.initial_qty += qty
+        self.state.entry = total / self.state.qty
+        if self.state.side == "LONG":
+            self.sl = self.state.entry - self.sl_atr * self.state.atr
+            self.tp1 = self.state.entry + self.tp1_atr * self.state.atr
+            self.tp2 = self.state.entry + self.tp2_atr * self.state.atr
+        else:
+            self.sl = self.state.entry + self.sl_atr * self.state.atr
+            self.tp1 = self.state.entry - self.tp1_atr * self.state.atr
+            self.tp2 = self.state.entry - self.tp2_atr * self.state.atr
+
+    # ------------------------------------------------------------------
     def _close_fraction(self, frac: float) -> float:
         qty_close = min(self.state.qty, self.initial_qty * frac)
         self.state.qty -= qty_close

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -16,3 +16,13 @@ def test_tp1_trailing():
     assert trail and trail > 0
     pm.on_tick(trail - 0.01)
     assert pm.state.qty == 0
+
+
+def test_add_updates_entry():
+    pm = PositionManager()
+    pm.open(side="LONG", qty=1, entry=100, atr=2)
+    pm.add(1, 98)
+    assert pm.state.qty == 2
+    assert pm.initial_qty == 2
+    assert pm.state.entry == pytest.approx(99, rel=1e-2)
+    assert pm.sl == pytest.approx(pm.state.entry - pm.sl_atr * pm.state.atr)

--- a/tests/test_symbol_integration.py
+++ b/tests/test_symbol_integration.py
@@ -1,0 +1,37 @@
+import asyncio
+import pytest
+
+from src.symbol_engine import SymbolEngine
+from src.strategy.bounce_entry import BounceEntry, EntrySignal
+from src.strategy.dca import SmartDCA
+from src.core.data import Bar
+from src.core import indicators
+
+
+def test_entry_dca_exit(monkeypatch):
+    se = SymbolEngine("BTCUSDT")
+
+    # patch indicators for deterministic behaviour
+    monkeypatch.setattr(indicators, "atr", lambda *a, **k: 1.0)
+
+    signals = [EntrySignal.LONG, EntrySignal.NO, EntrySignal.NO]
+
+    def fake_sig(*args, **kwargs):
+        return signals.pop(0)
+
+    monkeypatch.setattr(BounceEntry, "generate_signal", staticmethod(fake_sig))
+    monkeypatch.setattr(SmartDCA, "allowed", staticmethod(lambda *a, **k: True))
+    monkeypatch.setattr(SmartDCA, "next_price", staticmethod(lambda *a, **k: 99))
+
+    bar1 = Bar(100, 101, 99, 100, 1, 0, 300)
+    bar2 = Bar(99, 100, 98, 99, 1, 300, 600)
+    bar3 = Bar(102, 103, 101, 102, 1, 600, 900)
+
+    asyncio.run(se._on_bar(bar1))
+    assert se.pm.state.qty == 1
+
+    asyncio.run(se._on_bar(bar2))
+    assert se.pm.state.qty == 2
+
+    asyncio.run(se._on_bar(bar3))
+    assert se.pm.closed_qty > 0


### PR DESCRIPTION
## Summary
- support increasing PositionManager position size
- wire PositionManager into SymbolEngine with SmartDCA logic
- test the new add() method
- test entry+DCA+exit integration

## Testing
- `pytest -q`