### PR TITLE
Add candle interval configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ python scripts/fetch_and_backtest_year.py --year 2025 --interval 5 --equity 1000
 Downloads all pairs listed in `[bybit].symbols`.
 
 Produces `backtests/summary_2025.json` and monthly equity CSVs.
+
+## Configuration
+
+Runtime options are read from `settings.toml`.  The parameter
+`candle_interval_sec` controls how long each aggregated candle lasts when the
+engine warms up.  Decreasing this value shortens the warm‑up period without
+changing any code.

--- a/app/config.py
+++ b/app/config.py
@@ -55,6 +55,7 @@ class TradingSettings(BaseModel):
     enable_hedging: bool = False
     max_hedges: int = 1
     hedge_delay_seconds: float = 0.0
+    candle_interval_sec: int = 15
     enable_hedge_adx_filter: bool = False
     hedge_adx_threshold: float = 20.0
     hedge_size_ratio: float = 1.0

--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -134,7 +134,7 @@ class SymbolEngine:
         )
         self._last_mt_update: float = 0.0
         self._mt_candles: dict[str, list] = defaultdict(list)
-        self._candle_agg = CandleAggregator()
+        self._candle_agg = CandleAggregator(settings.trading.candle_interval_sec)
         self.ohlc = OHLCCollector()
         self.ohlc.subscribe(self._on_bar)
 

--- a/settings.toml
+++ b/settings.toml
@@ -53,6 +53,7 @@ adx_threshold             = 25.0
 enable_hedging            = true
 max_hedges                = 5
 hedge_delay_seconds       = 2
+candle_interval_sec       = 15     # длина свечи (с) для быстрой инициализации
 
 ########################  Multi-time-frame filter  #############################
 [multi_tf]


### PR DESCRIPTION
## Summary
- allow configuring candle interval
- pass `candle_interval_sec` to `SymbolEngine`
- document the new option

## Testing
- `pytest -q`