### PR TITLE
Enforce sequential entries

### DIFF
--- a/app/symbol_engine_manager.py
+++ b/app/symbol_engine_manager.py
@@ -60,6 +60,8 @@ class SymbolEngineManager:
         if not self.guard.allow_new_position(risk_pct):
             print("Portfolio risk cap hit")
             return
+        if engine.entry_order_id is not None or engine.risk.position.qty > 0:
+            return
         await engine._open_position(direction, price)
         self.account.open_positions.append(NS(symbol=engine.symbol, risk_pct=risk_pct))
 


### PR DESCRIPTION
## Summary
- wait for entry orders to fill before proceeding
- block new entries while a limit order or position is active

## Testing
- `pytest -q`