### PR TITLE
Switch to market orders

### DIFF
--- a/app/exchange.py
+++ b/app/exchange.py
@@ -109,8 +109,18 @@ class BybitClient:
                 )
                 await asyncio.sleep(wait)
 
-    async def create_market_order(self, side: str, qty: float):
-        """Place a market order with a unique ``orderLinkId``."""
+    async def create_market_order(self, side: str, qty: float, reduce_only: bool = False):
+        """Place a market order with a unique ``orderLinkId``.
+
+        Parameters
+        ----------
+        side : str
+            Order side, ``"Buy"`` or ``"Sell"``.
+        qty : float
+            Order quantity.
+        reduce_only : bool, optional
+            Submit order in reduce-only mode when ``True``.
+        """
         if not self.place_orders:
             print(f"[{self.symbol}] 🚫 create_market_order suppressed: {side} {qty}")
             return {}
@@ -124,7 +134,8 @@ class BybitClient:
                     side=side,
                     orderType="Market",
                     qty=qty,
-                    reduceOnly=False,
+                    reduceOnly=reduce_only,
+                    timeInForce="IOC",
                     orderLinkId=link_id,
                 )
             except InvalidRequestError as e:

--- a/app/strategy_utils.py
+++ b/app/strategy_utils.py
@@ -124,7 +124,7 @@ async def maybe_hedge(
     side_flip = "Sell" if side == "Buy" else "Buy"
     await engine._close_position("SOFT_SL", price)
     try:
-        await engine.client.create_limit_order(side_flip, hedge_qty, price)
+        await engine.client.create_market_order(side_flip, hedge_qty)
     except Exception as exc:  # pragma: no cover - network call
         print(f"[{engine.symbol}] Hedge failed: {exc}")
         return
@@ -158,7 +158,7 @@ async def handle_dca(engine, price: float) -> None:
     except Exception as exc:  # pragma: no cover - network call
         print(f"[{engine.symbol}] DCA qty calc failed: {exc}")
         return
-    await engine.client.create_limit_order(engine.risk.position.side, qty, price)
+    await engine.client.create_market_order(engine.risk.position.side, qty)
     RiskManager.position_volumes[engine.symbol] = (
         RiskManager.position_volumes.get(engine.symbol, 0.0) + qty * price
     )

--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -498,7 +498,7 @@ class SymbolEngine:
         except Exception as exc:
             print(f"[{self.symbol}] Qty calc failed: {exc}")
             return
-        resp = await self.client.create_limit_order(side, qty, price)
+        resp = await self.client.create_market_order(side, qty)
         order_id = resp.get("result", {}).get("orderId") if isinstance(resp, dict) else None
         if order_id:
             self.entry_order_id = order_id
@@ -554,10 +554,9 @@ class SymbolEngine:
         if close_qty > 0:
             side_close = "Sell" if self.risk.position.side == "Buy" else "Buy"
             try:
-                resp = await self.client.create_limit_order(
+                resp = await self.client.create_market_order(
                     side_close,
                     close_qty,
-                    price,
                     reduce_only=True,
                 )
                 order_id = resp.get("result", {}).get("orderId") if isinstance(resp, dict) else None
@@ -605,10 +604,9 @@ class SymbolEngine:
             return
         side_close = "Sell" if self.risk.position.side == "Buy" else "Buy"
         try:
-            resp = await self.client.create_limit_order(
+            resp = await self.client.create_market_order(
                 side_close,
                 close_qty,
-                price,
                 reduce_only=True,
             )
             order_id = resp.get("result", {}).get("orderId") if isinstance(resp, dict) else None
@@ -642,10 +640,9 @@ class SymbolEngine:
         if qty_close <= 0:
             return
         try:
-            resp = await self.client.create_limit_order(
+            resp = await self.client.create_market_order(
                 side_close,
                 qty_close,
-                mkt_price,
                 reduce_only=True,
             )
             order_id = resp.get("result", {}).get("orderId") if isinstance(resp, dict) else None


### PR DESCRIPTION
## Summary
- extend `create_market_order` to support `reduce_only` orders
- open and close positions using market orders
- use market orders for DCA and hedging

## Testing
- `pytest -q`