### PR TITLE
Pass signal reason to hedge

### DIFF
--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -541,7 +541,14 @@ class SymbolEngine:
             await self._handle_tp1(price)
         else:  # TP, SOFT_SL, TRAIL or TIMEOUT
             if signal in ("SOFT_SL", "TRAIL") and settings.trading.enable_hedging:
-                await maybe_hedge(self, self.risk.position.side, self.risk.position.qty, price, datetime.utcnow())
+                await maybe_hedge(
+                    self,
+                    self.risk.position.side,
+                    self.risk.position.qty,
+                    price,
+                    datetime.utcnow(),
+                    signal,
+                )
                 return
             await self._close_position(signal, price)
 


### PR DESCRIPTION
## Notes
- added `reason` parameter to `maybe_hedge`
- used reason when closing a position during hedging
- `_manage_position` now forwards the detected exit signal to `maybe_hedge`

## Testing
- `pytest -q`