### PR TITLE
Fix limit order parameters in market making mode

### DIFF
--- a/app/hybrid_strategy_engine.py
+++ b/app/hybrid_strategy_engine.py
@@ -101,8 +101,13 @@ class HybridStrategyEngine(SymbolEngine):
         ask = mid + spread
         self.mm_order_time = time.time()
         try:
-            self.buy_order_id = (await self.client.create_limit_order("Buy", bid, 0.001)).get("result", {}).get("orderId")
-            self.sell_order_id = (await self.client.create_limit_order("Sell", ask, 0.001)).get("result", {}).get("orderId")
+            # qty comes first, then price
+            self.buy_order_id = (
+                await self.client.create_limit_order("Buy", 0.001, bid)
+            ).get("result", {}).get("orderId")
+            self.sell_order_id = (
+                await self.client.create_limit_order("Sell", 0.001, ask)
+            ).get("result", {}).get("orderId")
         except Exception as exc:
             print(f"[{self.symbol}] MM order error: {exc}")
 


### PR DESCRIPTION
## Summary
- fix argument order for `create_limit_order` in `HybridStrategyEngine`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a054ecb1c8322993f6324c9404c3d