### PR TITLE
Fix MM order quantity to meet 5 USDT minimum

### DIFF
--- a/app/hybrid_strategy_engine.py
+++ b/app/hybrid_strategy_engine.py
@@ -101,8 +101,15 @@ class HybridStrategyEngine(SymbolEngine):
         ask = mid + spread
         self.mm_order_time = time.time()
         try:
-            self.buy_order_id = (await self.client.create_limit_order("Buy", bid, 0.001)).get("result", {}).get("orderId")
-            self.sell_order_id = (await self.client.create_limit_order("Sell", ask, 0.001)).get("result", {}).get("orderId")
+            step = self.precision.step(self.client.http, self.symbol)
+            min_qty = max(step, math.ceil((5 / mid) / step) * step)
+            # qty comes first, then price
+            self.buy_order_id = (
+                await self.client.create_limit_order("Buy", min_qty, bid)
+            ).get("result", {}).get("orderId")
+            self.sell_order_id = (
+                await self.client.create_limit_order("Sell", min_qty, ask)
+            ).get("result", {}).get("orderId")
         except Exception as exc:
             print(f"[{self.symbol}] MM order error: {exc}")
 


### PR DESCRIPTION
## Summary
- calculate MM order quantity using price step
- ensure order value is at least 5 USDT before placing the order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a054ecb1c8322993f6324c9404c3d