### PR TITLE
Update bounce entry import

### DIFF
--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -16,7 +16,7 @@ from app.exchange import BybitClient
 from app.market_features import MarketFeatures
 from app.notifier import notify_telegram
 from app.risk import RiskManager
-from legacy.strategy.bounce_entry import BounceEntry
+from legacy.strategy.bounce_entry import BounceEntry, EntrySignal
 from app.signal_engine import SignalEngine
 from app.utils import snap_qty
 from app.strategy_utils import (


### PR DESCRIPTION
## Summary
- export `EntrySignal` in symbol engine from bounce entry module

## Testing
- `ruff check --fix app legacy tests scripts` *(fails: E402, E741)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a1b2cd568832284bdc2b3e5eae5b2