### PR TITLE
Fix docstring ordering

### DIFF
--- a/app/hybrid_strategy_engine.py
+++ b/app/hybrid_strategy_engine.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Hybrid strategy engine combining SymbolEngine with extra filters."""
+from __future__ import annotations
 
 import asyncio
 import math

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Lightweight settings loader with sensible defaults."""
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict

--- a/legacy/core/indicators.py
+++ b/legacy/core/indicators.py
@@ -1,5 +1,5 @@
-from __future__ import annotations
 """Indicator utilities used across the project."""
+from __future__ import annotations
 
 from typing import Sequence, Tuple
 import statistics

--- a/legacy/market_features.py
+++ b/legacy/market_features.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Market micro-structure features used by strategies."""
+from __future__ import annotations
 
 from collections import deque
 import statistics

--- a/legacy/strategy/hedge.py
+++ b/legacy/strategy/hedge.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Hedging helpers implementing volume ratios and trigger rules."""
+from __future__ import annotations
 
 from typing import Tuple
 

--- a/legacy/strategy/manager.py
+++ b/legacy/strategy/manager.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Simple position management for backtesting."""
+from __future__ import annotations
 
 from dataclasses import dataclass
 


### PR DESCRIPTION
## Notes
- reposition module docstrings at the top of their files
- keep existing imports other than moving `from __future__ import annotations`
- ran `ruff check --fix app legacy tests scripts` and tests

## Testing
- `ruff check --fix app legacy tests scripts` *(fails: Found 16 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a1b2ce16c8322b2ff335a56721348