### PR TITLE
Rename 'l' variables

### DIFF
--- a/legacy/core/data.py
+++ b/legacy/core/data.py
@@ -34,12 +34,12 @@ class OHLCCollector:
             self._emit(bar)
             self._bar = Bar(price, price, price, price, qty, bucket, bucket + self.interval)
             return
-        o, h, l, c, v, s, e = self._bar
+        o, h, low, c, v, s, e = self._bar
         h = max(h, price)
-        l = min(l, price)
+        low = min(low, price)
         c = price
         v += qty
-        self._bar = Bar(o, h, l, c, v, s, e)
+        self._bar = Bar(o, h, low, c, v, s, e)
 
 
 """

--- a/legacy/core/indicators.py
+++ b/legacy/core/indicators.py
@@ -80,9 +80,9 @@ def compute_rsi(closes: Sequence[float], period: int) -> float | None:
         loss = [-d if d < 0 else 0.0 for d in diff]
     avg_gain = sum(gain[:period]) / period
     avg_loss = sum(loss[:period]) / period
-    for g, l in zip(gain[period:], loss[period:]):
+    for g, loss_val in zip(gain[period:], loss[period:]):
         avg_gain = (avg_gain * (period - 1) + g) / period
-        avg_loss = (avg_loss * (period - 1) + l) / period
+        avg_loss = (avg_loss * (period - 1) + loss_val) / period
     if avg_loss == 0:
         return 100.0
     rs = avg_gain / avg_loss
@@ -174,14 +174,14 @@ def atr(
 
     if np is not None:
         h = np.asarray(highs, dtype=float)
-        l = np.asarray(lows, dtype=float)
+        low_arr = np.asarray(lows, dtype=float)
         c = np.asarray(closes, dtype=float)
-        tr = h[1:] - l[1:]
+        tr = h[1:] - low_arr[1:]
     else:
         h = [float(x) for x in highs]
-        l = [float(x) for x in lows]
+        low_arr = [float(x) for x in lows]
         c = [float(x) for x in closes]
-        tr = [h[i] - l[i] for i in range(1, len(c))]
+        tr = [h[i] - low_arr[i] for i in range(1, len(c))]
     atr_v = sum(tr[:period]) / period
     for val in tr[period:]:
         atr_v = (atr_v * (period - 1) + val) / period
@@ -206,29 +206,29 @@ def adx(
 
     if np is not None:
         h = np.asarray(highs, dtype=float)
-        l = np.asarray(lows, dtype=float)
+        low_arr = np.asarray(lows, dtype=float)
         c = np.asarray(closes, dtype=float)
 
         up_move = h[1:] - h[:-1]
-        down_move = l[:-1] - l[1:]
+        down_move = low_arr[:-1] - low_arr[1:]
         plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
         minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
         tr = np.maximum.reduce([
-            h[1:] - l[1:],
+            h[1:] - low_arr[1:],
             np.abs(h[1:] - c[:-1]),
-            np.abs(l[1:] - c[:-1]),
+            np.abs(low_arr[1:] - c[:-1]),
         ])
     else:
         h = [float(x) for x in highs]
-        l = [float(x) for x in lows]
+        low_arr = [float(x) for x in lows]
         c = [float(x) for x in closes]
 
         up_move = [h[i] - h[i - 1] for i in range(1, len(h))]
-        down_move = [l[i - 1] - l[i] for i in range(1, len(l))]
+        down_move = [low_arr[i - 1] - low_arr[i] for i in range(1, len(low_arr))]
         plus_dm = [um if um > dm and um > 0 else 0.0 for um, dm in zip(up_move, down_move)]
         minus_dm = [dm if dm > um and dm > 0 else 0.0 for um, dm in zip(up_move, down_move)]
         tr = [
-            max(h[i] - l[i], abs(h[i] - c[i - 1]), abs(l[i] - c[i - 1]))
+            max(h[i] - low_arr[i], abs(h[i] - c[i - 1]), abs(low_arr[i] - c[i - 1]))
             for i in range(1, len(c))
         ]
 

--- a/scripts/backtest_year.py
+++ b/scripts/backtest_year.py
@@ -20,8 +20,8 @@ from helpers.metrics import sharpe, profit_factor, max_drawdown
 
 def load_bars(path: str):
     with open(path) as f:
-        for ts, o, h, l, c, v in csv.reader(f):
-            yield float(o), float(h), float(l), float(c), float(v), int(ts)
+        for ts, o, h, low, c, v in csv.reader(f):
+            yield float(o), float(h), float(low), float(c), float(v), int(ts)
 
 
 async def backtest(

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -4,7 +4,7 @@ from legacy.core import indicators
 def test_atr_constant_range():
     high = [float(i) for i in range(1, 16)]
     low = [h - 1.5 for h in high]
-    close = [(h + l) / 2 for h, l in zip(high, low)]
+    close = [(h + low_val) / 2 for h, low_val in zip(high, low)]
     atr = indicators.atr(high, low, close, period=14)
     assert round(float(atr), 4) == 1.5
 


### PR DESCRIPTION
## Summary
- rename ambiguous variable `l` to `low`
- update backtesting script to use `low`
- use `low_val` in indicators test

## Testing
- `ruff check | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a1b30e30c8322a031f5a339e25fa3