### PR TITLE
Organize imports in test modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,14 @@
 import asyncio
-import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import sys
 import types
+from collections import namedtuple
+
+import pytest
+
+from legacy.core.data import Bar
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 pybit = types.ModuleType("pybit")
 pybit.exceptions = types.SimpleNamespace(InvalidRequestError=Exception)
 sys.modules.setdefault("pybit", pybit)
@@ -37,10 +43,6 @@ sys.modules.setdefault("urllib3", urllib3_mod)
 aiohttp_mod = types.ModuleType("aiohttp")
 aiohttp_mod.ClientSession = object
 sys.modules.setdefault("aiohttp", aiohttp_mod)
-from collections import namedtuple
-import pytest
-
-from legacy.core.data import Bar
 
 Trade = namedtuple("Trade", "price qty ts")
 

--- a/tests/test_indicators_vectorized.py
+++ b/tests/test_indicators_vectorized.py
@@ -1,10 +1,9 @@
 import time
 
 import pytest
+from legacy.core.indicators_vectorized import atr, compute_adx, compute_rsi
 
 np = pytest.importorskip("numpy")
-
-from legacy.core.indicators_vectorized import atr, compute_adx, compute_rsi
 
 
 # --- tiny Python reference versions (for correctness check) --------------------


### PR DESCRIPTION
## Summary
- move import statements to the top of tests/conftest.py
- move import statements to the top of tests/test_indicators_vectorized.py
- verify no ruff lint errors for modified files

## Testing
- `ruff check tests/conftest.py tests/test_indicators_vectorized.py`

------
https://chatgpt.com/codex/tasks/task_e_683a1b322214832292c5e6b070dbdec0