### PR TITLE
Add hedge execution logs

### DIFF
--- a/app/strategy_utils.py
+++ b/app/strategy_utils.py
@@ -129,6 +129,10 @@ async def maybe_hedge(
     except Exception as exc:  # pragma: no cover - network call
         print(f"[{engine.symbol}] Hedge failed: {exc}")
         return
+    print(f"[{engine.symbol}] ♻️ Hedge {side_flip} {hedge_qty}")
+    await notify_telegram(
+        f"♻️ Hedge {engine.symbol}: {side_flip} qty={hedge_qty}"
+    )
 
     engine.hedge_cycle_count += 1
     RiskManager.active_positions.add(engine.symbol)


### PR DESCRIPTION
## Summary
- add console and telegram logs on hedge execution

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a1da7ea908322876109591cb86344