### PR TITLE
Fix strategy mode detection and tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,9 @@ from collections import namedtuple
 
 import pytest
 
-from legacy.core.data import Bar
-
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from legacy.core.data import Bar
 pybit = types.ModuleType("pybit")
 pybit.exceptions = types.SimpleNamespace(InvalidRequestError=Exception)
 sys.modules.setdefault("pybit", pybit)

--- a/tests/test_engine_selection.py
+++ b/tests/test_engine_selection.py
@@ -1,0 +1,53 @@
+import sys
+import types
+
+# minimal settings stub
+trading = types.SimpleNamespace(
+    strategy_mode="hybrid",
+    leverage=1,
+    enable_hedging=False,
+    candle_interval_sec=1,
+    rsi_period=14,
+    adx_period=14,
+    initial_risk_percent=1.0,
+    max_position_risk_percent=0,
+    max_dca_levels=1,
+)
+entry_score = types.SimpleNamespace(symbol_weights={}, weights={}, threshold_k=1.0, symbol_threshold_k={})
+settings_stub = types.SimpleNamespace(
+    bybit=types.SimpleNamespace(api_key="", api_secret="", testnet=False, demo=False, place_orders=False, channel_type="linear", symbols=["BTCUSDT"]),
+    trading=trading,
+    risk=types.SimpleNamespace(max_open_positions=0, daily_trades_limit=0, enable_daily_trades_guard=False),
+    telegram=None,
+    entry_score=entry_score,
+    multi_tf=types.SimpleNamespace(enable=False, intervals=[]),
+    symbol_params={},
+)
+
+sys.modules['app.config'] = types.SimpleNamespace(settings=settings_stub)
+
+
+class DummyClient:
+    def __init__(self, symbol, api_key="", api_secret="", testnet=False, demo=False, channel_type="linear", place_orders=True):
+        self.symbol = symbol
+        self.http = types.SimpleNamespace(api_key=api_key, api_secret=api_secret, testnet=testnet, demo=demo)
+        self.place_orders = place_orders
+        self.channel_type = channel_type
+
+    def set_leverage(self, *a, **k):
+        pass
+
+sys.modules['app.exchange'] = types.SimpleNamespace(BybitClient=DummyClient)
+
+from app.symbol_engine_manager import SymbolEngineManager, HybridStrategyEngine, SymbolEngine
+
+
+def test_engine_class_hybrid():
+    mgr = SymbolEngineManager(["BTCUSDT"])
+    assert mgr._engine_class() is HybridStrategyEngine
+
+
+def test_engine_class_basic():
+    settings_stub.trading.strategy_mode = "basic"
+    mgr = SymbolEngineManager(["BTCUSDT"])
+    assert mgr._engine_class() is SymbolEngine


### PR DESCRIPTION
## Summary
- ensure tests add repo root to `sys.path` before importing
- set daily trade limit in `SymbolEngineManager`
- add `_engine_class` helper to choose hybrid vs basic engine
- retry engine restarts with updated strategy mode
- test engine class selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a232aa3c08322b4cb3ca21806d986