### PR TITLE
Improve SL placement reliability

### DIFF
--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -744,7 +744,10 @@ class SymbolEngine:
 
         current = current_price
         if current is None:
-            current = self.close_window[-1] if self.close_window else None
+            if self.market.price_window:
+                current = self.market.price_window[-1]
+            else:
+                current = self.close_window[-1] if self.close_window else None
         if current is not None:
             if self.risk.position.side == "Buy" and sl_price >= current:
                 sl_price = current * 0.999


### PR DESCRIPTION
## Summary
- use the latest tick price when adjusting stop loss levels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a28bb2ad883229e00fe207a6edd2e