### PR TITLE
Fix duplicate position entries

### DIFF
--- a/app/symbol_engine_manager.py
+++ b/app/symbol_engine_manager.py
@@ -91,7 +91,7 @@ class SymbolEngineManager:
         if not guard.allow_new_position(risk_pct):
             print("🚫 Portfolio risk cap hit")
             return False
-        if engine.entry_order_id is not None or engine.risk.position.qty > 0:
+        if engine._opening or engine.entry_order_id is not None or engine.risk.position.qty > 0:
             return False
         await engine._open_position(direction, price)
         self.account.open_positions.append(NS(symbol=engine.symbol, risk_pct=risk_pct))


### PR DESCRIPTION
## Summary
- add `_opening` flag and lock in `SymbolEngine`
- use this flag in `SymbolEngineManager` to prevent racing entries

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c2e480e68832284fa26de790a6a4d