### PR TITLE
Fix missing try block in HttpClient

### DIFF
--- a/app/http_client.py
+++ b/app/http_client.py
@@ -58,7 +58,8 @@ class HttpClient:
 
     @async_retry_rest()
     async def get_risk_limit(self, **params):
-        return await asyncio.to_thread(self.http.get_risk_limit, **params)
+        try:
+            return await asyncio.to_thread(self.http.get_risk_limit, **params)
         except (requests.ConnectionError, urllib3.exceptions.ProtocolError):
             self.http = HTTP(
                 api_key=self.http.api_key,


### PR DESCRIPTION
## Summary
- fix unbalanced try/except in `get_risk_limit`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `python main.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_683c30c56c0c8322b82ece1e5b96ebd8