### PR TITLE
Fix ModuleNotFoundError for ml_model

### DIFF
--- a/app/ml_model.py
+++ b/app/ml_model.py
@@ -1,0 +1,23 @@
+import pathlib
+
+try:
+    import joblib
+except Exception:  # pragma: no cover - optional dependency
+    joblib = None
+
+
+class MLModel:
+    """Load optional ML model for signal filtering."""
+
+    def __init__(self, path: str = "models/ml_model.pkl") -> None:
+        p = pathlib.Path(path)
+        if joblib and p.exists():
+            self.model = joblib.load(p)
+        else:
+            self.model = None
+
+    def allow(self, feats: list[float] | tuple[float, ...]) -> bool:
+        """Return True if the features pass the ML filter."""
+        if self.model is None:
+            return True
+        return bool(self.model.predict([feats])[0])


### PR DESCRIPTION
## Summary
- restore missing `app.ml_model` module so optional ML filtering works

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_683c317a82048322a5a426c14160efb9