### PR TITLE
Improve position logging

### DIFF
--- a/app/strategy_utils.py
+++ b/app/strategy_utils.py
@@ -103,7 +103,7 @@ async def maybe_hedge(
     stg = settings.trading
 
     if engine.hedge_cycle_count >= stg.max_hedges:
-        await engine._close_position(reason, price)
+        await engine._close_position(reason, price, reason)
         return
 
     if stg.hedge_delay_seconds > 0:
@@ -113,17 +113,17 @@ async def maybe_hedge(
         closes = [c for _, _, c in engine.risk.price_window]
         adx = compute_adx(closes, settings.trading.adx_period)
         if adx is None or adx < stg.hedge_adx_threshold:
-            await engine._close_position(reason, price)
+            await engine._close_position(reason, price, reason)
             return
 
     step = engine.precision.step(engine.client.http, engine.symbol)
     hedge_qty = snap_qty(qty * stg.hedge_size_ratio, step)
     if hedge_qty <= 0:
-        await engine._close_position(reason, price)
+        await engine._close_position(reason, price, reason)
         return
 
     side_flip = "Sell" if side == "Buy" else "Buy"
-    await engine._close_position(reason, price)
+    await engine._close_position(reason, price, reason)
     try:
         await engine.client.create_market_order(side_flip, hedge_qty)
     except Exception as exc:  # pragma: no cover - network call

--- a/app/symbol_engine_manager.py
+++ b/app/symbol_engine_manager.py
@@ -81,7 +81,15 @@ class SymbolEngineManager:
         self.tasks["cmd"] = asyncio.create_task(telegram_command_listener())
         await asyncio.gather(*self.tasks.values())
 
-    async def _maybe_open_position(self, engine: SymbolEngine, direction: str, price: float) -> bool:
+    async def _maybe_open_position(
+        self,
+        engine: SymbolEngine,
+        direction: str,
+        price: float,
+        reason: str | None = None,
+        filters: str | None = None,
+        features: str | None = None,
+    ) -> bool:
         risk_pct = settings.trading.initial_risk_percent
         guard = self.guard
         if settings.risk.enable_daily_trades_guard:
@@ -93,7 +101,7 @@ class SymbolEngineManager:
             return False
         if engine.entry_order_id is not None or engine.risk.position.qty > 0:
             return False
-        await engine._open_position(direction, price)
+        await engine._open_position(direction, price, reason, filters, features)
         self.account.open_positions.append(NS(symbol=engine.symbol, risk_pct=risk_pct))
         guard.inc_trade()
         return True

--- a/tests/test_hybrid_strategy_engine.py
+++ b/tests/test_hybrid_strategy_engine.py
@@ -116,7 +116,7 @@ def test_open_position_filters(monkeypatch):
     engine.market.price_window.extend([100, 99, 98, 97, 96])
     called = False
 
-    async def dummy_open(self, direction, price):
+    async def dummy_open(self, direction, price, reason=None, filters=None, features=None):
         nonlocal called
         called = True
 

--- a/tests/test_risk_exit.py
+++ b/tests/test_risk_exit.py
@@ -35,11 +35,11 @@ for _ in range(20):
 
 @pytest.mark.asyncio
 async def test_hard_sl_trigger():
-    sig = await rm.check_exit(97)
+    sig, reason = await rm.check_exit(97)
     assert sig == "HARD_SL"
 
 @pytest.mark.asyncio
 async def test_atr_stop_trigger():
     trading.hard_sl_percent = 0.0
-    sig = await rm.check_exit(96)
+    sig, reason = await rm.check_exit(96)
     assert sig == "SOFT_SL"


### PR DESCRIPTION
## Summary
- extend `_open_position` to include filters and features
- send rich entry/exit info to Telegram
- plumb new parameters through manager and hybrid engine
- update tests for new signature

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c8065af248322bbd17d9d45c501a2