### PR TITLE
Add exit reason logging

### DIFF
--- a/app/strategy_utils.py
+++ b/app/strategy_utils.py
@@ -147,7 +147,7 @@ async def maybe_hedge(
     await engine._set_sl(hedge_qty, sl_px, price)
 
 
-async def handle_dca(engine, price: float) -> None:
+async def handle_dca(engine, price: float, reason: str | None = None) -> None:
     base = settings.trading.initial_risk_percent
     q = settings.trading.dca_risk_multiplier
     risk_pct = base * (q ** engine.risk.dca_levels)
@@ -177,7 +177,11 @@ async def handle_dca(engine, price: float) -> None:
     engine.risk.initial_qty = total_qty
     engine.risk.entry_value += qty * price
     engine.risk.last_dca_price = price
-    await notify_telegram(f"➕ DCA {engine.symbol}: +{qty} → avg {new_avg:.4f}")
+    msg = (
+        f"➕ DCA {engine.symbol}: +{qty} → avg {new_avg:.4f}\n"
+        f"📉 Reason: {reason or 'n/a'}"
+    )
+    await notify_telegram(msg)
 
     sl_px = engine._soft_sl_price(new_avg, engine.risk.position.side)
     await engine._set_sl(total_qty, sl_px, price)

--- a/tests/test_risk_exit.py
+++ b/tests/test_risk_exit.py
@@ -1,5 +1,4 @@
 import types
-import asyncio
 from datetime import datetime, timedelta
 import sys
 import pytest


### PR DESCRIPTION
## Summary
- log exit reasons when handling partial TP and DCA actions
- include reason field in TP1/TP2 Telegram messages
- pass exit reason into `handle_dca`
- remove an unused import from `tests/test_risk_exit.py`

## Testing
- `ruff check --fix app/symbol_engine.py app/strategy_utils.py tests/test_risk_exit.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb84da3608322a83e6b93dff68e73