### PR TITLE
Fix trailing stop after TP1

### DIFF
--- a/app/risk.py
+++ b/app/risk.py
@@ -332,7 +332,14 @@ class RiskManager:
             ):
                 self.tp1_done = True
                 self.best_price = price
-                self.trail_price = self.position.avg_price
+                if self.position.side == "Buy":
+                    self.trail_price = price * (
+                        1 - settings.trading.trailing_distance_percent / 100
+                    )
+                else:
+                    self.trail_price = price * (
+                        1 + settings.trading.trailing_distance_percent / 100
+                    )
                 reason = f"TP1 hit at change {change:.2f}%"
                 print(f"[{self.symbol}] {reason}")
                 return "TP1", reason

--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -702,15 +702,12 @@ class SymbolEngine:
                 f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
             )
             await notify_telegram(msg)
-        # move SL to breakeven with a small profit buffer
-        be = settings.trading.min_profit_to_be
-        if be:
-            if self.risk.position.side == "Buy":
-                sl_px = self.risk.position.avg_price * (1 + be / 100)
-            else:
-                sl_px = self.risk.position.avg_price * (1 - be / 100)
+        # set initial trailing stop after TP1
+        dist = settings.trading.trailing_distance_percent / 100
+        if self.risk.position.side == "Buy":
+            sl_px = price * (1 - dist)
         else:
-            sl_px = self.risk.position.avg_price
+            sl_px = price * (1 + dist)
         await self._set_sl(self.risk.position.qty, sl_px, price)
 
     async def _handle_tp2(self, price: float, reason: str | None = None) -> None:


### PR DESCRIPTION
## Summary
- set trailing stop distance based on TP1 price
- update stop placement to use trailing distance after TP1

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'legacy')*

------
https://chatgpt.com/codex/tasks/task_e_683cbcae7a788322bd86cd620026604d