### PR TITLE
Improve Telegram trade details

### DIFF
--- a/app/risk.py
+++ b/app/risk.py
@@ -392,7 +392,7 @@ class RiskManager:
             self.dca_levels += 1
             self.last_dca_price = price
             self.last_dca_time = datetime.utcnow()
-            reason = f"DCA level {self.dca_levels+1} triggered"
+            reason = f"DCA level {self.dca_levels+1} triggered at change {change:.2f}%"
             print(f"[{self.symbol}] {reason}")
             return "DCA", reason
 

--- a/app/strategy_utils.py
+++ b/app/strategy_utils.py
@@ -168,6 +168,11 @@ async def handle_dca(engine, price: float, reason: str | None = None) -> None:
         RiskManager.position_volumes.get(engine.symbol, 0.0) + qty * price
     )
 
+    delta_pct = (
+        (price - engine.risk.position.avg_price)
+        / engine.risk.position.avg_price
+        * 100
+    )
     total_qty = engine.risk.position.qty + qty
     new_avg = (
         engine.risk.position.avg_price * engine.risk.position.qty + price * qty
@@ -177,9 +182,11 @@ async def handle_dca(engine, price: float, reason: str | None = None) -> None:
     engine.risk.initial_qty = total_qty
     engine.risk.entry_value += qty * price
     engine.risk.last_dca_price = price
+    direction = "LONG" if engine.risk.position.side == "Buy" else "SHORT"
     msg = (
-        f"➕ DCA {engine.symbol}: +{qty} → avg {new_avg:.4f}\n"
-        f"📉 Reason: {reason or 'n/a'}"
+        f"➕ DCA {engine.symbol} {direction}: +{qty} → avg {new_avg:.4f}\n"
+        f"📉 Reason: {reason or 'n/a'}\n"
+        f"Δ%: {delta_pct:.2f}%"
     )
     await notify_telegram(msg)
 

--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -602,8 +602,9 @@ class SymbolEngine:
             self.entry_order_id = order_id
             await self._wait_order_fill(order_id)
             self.entry_order_id = None
+        direction_label = "LONG" if side == "Buy" else "SHORT"
         log_msg = (
-            f"📥 Entry {self.symbol} {side} qty={qty:.2f}\n"
+            f"📥 Entry {self.symbol} {direction_label} qty={qty:.2f} @ {price:.4f}\n"
             f"📊 Reason: {reason or 'n/a'}\n"
             f"✅ Filters passed: {filters or 'none'}"
         )
@@ -697,8 +698,9 @@ class SymbolEngine:
             net_usdt = self.risk.realized_pnl
             emoji = "🟢" if net_usdt > 0 else "🔴"
             sign  = "+" if net_usdt > 0 else ""
+            direction_label = "LONG" if self.risk.position.side == "Buy" else "SHORT"
             msg = (
-                f"{emoji} <b>TP1 {self.symbol}</b>\n"
+                f"{emoji} <b>TP1 {self.symbol} {direction_label}</b>\n"
                 f"📉 Reason: {reason or 'n/a'}\n"
                 f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
             )
@@ -745,8 +747,9 @@ class SymbolEngine:
         net_usdt = self.risk.realized_pnl
         emoji = "🟢" if net_usdt > 0 else "🔴"
         sign = "+" if net_usdt > 0 else ""
+        direction_label = "LONG" if self.risk.position.side == "Buy" else "SHORT"
         msg = (
-            f"{emoji} <b>TP2 {self.symbol}</b>\n"
+            f"{emoji} <b>TP2 {self.symbol} {direction_label}</b>\n"
             f"📉 Reason: {reason or 'n/a'}\n"
             f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
         )
@@ -785,8 +788,9 @@ class SymbolEngine:
         sign  = "+" if net_usdt > 0 else ""
         duration = datetime.utcnow() - self.risk.position.open_time
         dur_str = str(duration).split(".")[0]
+        direction_label = "LONG" if self.risk.position.side == "Buy" else "SHORT"
         msg = (
-            f"{emoji} <b>{exit_signal} {self.symbol}</b>\n"
+            f"{emoji} <b>{exit_signal} {self.symbol} {direction_label}</b>\n"
             f"📉 Reason: {reason or 'n/a'}\n"
             f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
             f"🕑 Duration: {dur_str}"


### PR DESCRIPTION
## Summary
- include price change in DCA reason
- add current position side to entry/exit notifications
- report DCA price delta in messages

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683db0b844048322b872771d6abe9186