### PR TITLE
Update entry log message

### DIFF
--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -603,7 +603,7 @@ class SymbolEngine:
             await self._wait_order_fill(order_id)
             self.entry_order_id = None
         log_msg = (
-            f"📥 Entry {self.symbol} {side} qty={qty:.2f}\n"
+            f"📥 Entry {self.symbol} {direction.capitalize()} qty={qty:.2f}\n"
             f"📊 Reason: {reason or 'n/a'}\n"
             f"✅ Filters passed: {filters or 'none'}"
         )


### PR DESCRIPTION
## Summary
- show trade direction as `Long`/`Short` in entry log

## Testing
- `ruff check --fix app/symbol_engine.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dbbf793e4832283aaa70fe32984f0