### PR TITLE
Improve telegram logs with price context

### DIFF
--- a/app/strategy_utils.py
+++ b/app/strategy_utils.py
@@ -7,7 +7,7 @@ import statistics
 from datetime import datetime
 
 from app.config import settings
-from app.utils import snap_qty
+from app.utils import snap_qty, format_price_change
 from app.risk import RiskManager
 from app.notifier import notify_telegram
 from legacy.core.indicators import compute_adx
@@ -169,6 +169,7 @@ async def handle_dca(engine, price: float, reason: str | None = None) -> None:
     )
 
     total_qty = engine.risk.position.qty + qty
+    old_avg = engine.risk.position.avg_price
     new_avg = (
         engine.risk.position.avg_price * engine.risk.position.qty + price * qty
     ) / total_qty
@@ -177,9 +178,11 @@ async def handle_dca(engine, price: float, reason: str | None = None) -> None:
     engine.risk.initial_qty = total_qty
     engine.risk.entry_value += qty * price
     engine.risk.last_dca_price = price
+    change_info = format_price_change(price, old_avg)
     msg = (
         f"➕ DCA {engine.symbol}: +{qty} → avg {new_avg:.4f}\n"
-        f"📉 Reason: {reason or 'n/a'}"
+        f"📉 Reason: {reason or 'n/a'}\n"
+        f"📈 {change_info}"
     )
     await notify_telegram(msg)
 

--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -18,7 +18,7 @@ from app.notifier import notify_telegram
 from app.risk import RiskManager
 from legacy.strategy.bounce_entry import BounceEntry, EntrySignal
 from app.signal_engine import SignalEngine
-from app.utils import snap_qty
+from app.utils import snap_qty, format_price_change
 from app.strategy_utils import (
     entry_filters_fail,
     higher_tf_trend,
@@ -697,9 +697,11 @@ class SymbolEngine:
             net_usdt = self.risk.realized_pnl
             emoji = "🟢" if net_usdt > 0 else "🔴"
             sign  = "+" if net_usdt > 0 else ""
+            change_info = format_price_change(price, self.risk.position.avg_price)
             msg = (
                 f"{emoji} <b>TP1 {self.symbol}</b>\n"
                 f"📉 Reason: {reason or 'n/a'}\n"
+                f"📈 {change_info}\n"
                 f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
             )
             await notify_telegram(msg)
@@ -745,9 +747,11 @@ class SymbolEngine:
         net_usdt = self.risk.realized_pnl
         emoji = "🟢" if net_usdt > 0 else "🔴"
         sign = "+" if net_usdt > 0 else ""
+        change_info = format_price_change(price, self.risk.position.avg_price)
         msg = (
             f"{emoji} <b>TP2 {self.symbol}</b>\n"
             f"📉 Reason: {reason or 'n/a'}\n"
+            f"📈 {change_info}\n"
             f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
         )
         await notify_telegram(msg)
@@ -785,9 +789,11 @@ class SymbolEngine:
         sign  = "+" if net_usdt > 0 else ""
         duration = datetime.utcnow() - self.risk.position.open_time
         dur_str = str(duration).split(".")[0]
+        change_info = format_price_change(mkt_price, self.risk.position.avg_price)
         msg = (
             f"{emoji} <b>{exit_signal} {self.symbol}</b>\n"
             f"📉 Reason: {reason or 'n/a'}\n"
+            f"📈 {change_info}\n"
             f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
             f"🕑 Duration: {dur_str}"
         )

--- a/app/utils.py
+++ b/app/utils.py
@@ -7,4 +7,14 @@ def snap_qty(qty_raw: float, step: float) -> float:
     d_step = Decimal(str(step))
     d_raw  = Decimal(str(qty_raw))
     snapped = (d_raw // d_step) * d_step
-    return float(snapped.quantize(d_step, ROUND_DOWN)) 
+    return float(snapped.quantize(d_step, ROUND_DOWN))
+
+
+def format_price_change(current: float, reference: float) -> str:
+    """Return formatted price change string ``"ref → cur (+x.xx%)"``."""
+    if reference:
+        pct = (current - reference) / reference * 100
+    else:
+        pct = 0.0
+    sign = "+" if pct >= 0 else ""
+    return f"{reference:.4f} → {current:.4f} ({sign}{pct:.2f}%)"


### PR DESCRIPTION
## Summary
- add `format_price_change` helper
- include price change info in DCA messages
- add price context to TP1/TP2/close notifications

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dc5e21308832293b4de014815aebf