### PR TITLE
Fix take profit exits and test setup

### DIFF
--- a/app/risk.py
+++ b/app/risk.py
@@ -313,7 +313,7 @@ class RiskManager:
 
         # Fallback TP when partial TPs are disabled
         if settings.trading.tp1_percent is None and settings.trading.tp2_percent is None:
-            tp_pct = settings.trading.take_profit_percent
+            tp_pct = abs(settings.trading.take_profit_percent)
             if (
                 self.position.side == "Buy" and change >= tp_pct
             ) or (
@@ -325,10 +325,10 @@ class RiskManager:
 
         # TP1
         if not self.tp1_done:
-            if (
-                self.position.side == "Buy" and change >= settings.trading.tp1_percent
-            ) or (
-                self.position.side == "Sell" and change <= -settings.trading.tp1_percent
+            tp1_pct = abs(settings.trading.tp1_percent) if settings.trading.tp1_percent is not None else None
+            if tp1_pct is not None and (
+                (self.position.side == "Buy" and change >= tp1_pct)
+                or (self.position.side == "Sell" and change <= -tp1_pct)
             ):
                 self.tp1_done = True
                 self.best_price = price
@@ -345,10 +345,11 @@ class RiskManager:
                 return "TP1", reason
         if self.tp1_done and not self.tp2_done:
             if settings.trading.tp2_percent is not None:
+                tp2_pct = abs(settings.trading.tp2_percent)
                 if (
-                    self.position.side == "Buy" and change >= settings.trading.tp2_percent
+                    self.position.side == "Buy" and change >= tp2_pct
                 ) or (
-                    self.position.side == "Sell" and change <= -settings.trading.tp2_percent
+                    self.position.side == "Sell" and change <= -tp2_pct
                 ):
                     self.tp2_done = True
                     self.best_price = price
@@ -378,10 +379,11 @@ class RiskManager:
                     return "TRAIL", reason
 
         # TP
+        tp_pct_final = abs(settings.trading.take_profit_percent)
         if (
-            self.position.side == "Buy" and change >= settings.trading.take_profit_percent
+            self.position.side == "Buy" and change >= tp_pct_final
         ) or (
-            self.position.side == "Sell" and change <= -settings.trading.take_profit_percent
+            self.position.side == "Sell" and change <= -tp_pct_final
         ):
             reason = f"TP hit at change {change:.2f}%"
             print(f"[{self.symbol}] {reason}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,9 @@ from collections import namedtuple
 
 import pytest
 
-from legacy.core.data import Bar
-
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from legacy.core.data import Bar
 pybit = types.ModuleType("pybit")
 pybit.exceptions = types.SimpleNamespace(InvalidRequestError=Exception)
 sys.modules.setdefault("pybit", pybit)


### PR DESCRIPTION
## Summary
- ensure TP thresholds use absolute percentages
- fix tests path setup so imports resolve

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683df447f9bc83228d02caaa72b9d62e