### PR TITLE
Improve telegram logging

### DIFF
--- a/app/strategy_utils.py
+++ b/app/strategy_utils.py
@@ -186,6 +186,7 @@ async def handle_dca(engine, price: float, reason: str | None = None) -> None:
     msg = (
         f"➕ DCA {engine.symbol} {direction}: +{qty} → avg {new_avg:.4f}\n"
         f"📉 Reason: {reason or 'n/a'}\n"
+        f"📈 Price: {price:.4f}\n"
         f"Δ%: {delta_pct:.2f}%"
     )
     await notify_telegram(msg)

--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -693,7 +693,9 @@ class SymbolEngine:
             pnl = await _fetch_closed_pnl(self)
             if pnl:
                 self.risk.realized_pnl += pnl[0]
-            await notify_telegram(f"💰 TP1 {self.symbol}: {close_qty} closed")
+            await notify_telegram(
+                f"💰 TP1 {self.symbol}: {close_qty} closed @ {price:.4f}"
+            )
             total_pct = (
                 self.risk.realized_pnl / self.risk.entry_value * 100
                 if self.risk.entry_value else 0.0
@@ -705,6 +707,7 @@ class SymbolEngine:
             msg = (
                 f"{emoji} <b>TP1 {self.symbol} {direction_label}</b>\n"
                 f"📉 Reason: {reason or 'n/a'}\n"
+                f"📈 Price: {price:.4f}\n"
                 f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
             )
             await notify_telegram(msg)
@@ -742,7 +745,9 @@ class SymbolEngine:
         pnl = await _fetch_closed_pnl(self)
         if pnl:
             self.risk.realized_pnl += pnl[0]
-        await notify_telegram(f"💰 TP2 {self.symbol}: {close_qty} closed")
+        await notify_telegram(
+            f"💰 TP2 {self.symbol}: {close_qty} closed @ {price:.4f}"
+        )
         total_pct = (
             self.risk.realized_pnl / self.risk.entry_value * 100
             if self.risk.entry_value else 0.0
@@ -754,6 +759,7 @@ class SymbolEngine:
         msg = (
             f"{emoji} <b>TP2 {self.symbol} {direction_label}</b>\n"
             f"📉 Reason: {reason or 'n/a'}\n"
+            f"📈 Price: {price:.4f}\n"
             f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
         )
         await notify_telegram(msg)
@@ -795,6 +801,7 @@ class SymbolEngine:
         msg = (
             f"{emoji} <b>{exit_signal} {self.symbol} {direction_label}</b>\n"
             f"📉 Reason: {reason or 'n/a'}\n"
+            f"📈 Price: {mkt_price:.4f}\n"
             f"💰 PnL: <b>{sign}{net_usdt:.2f} USDT</b> ({sign}{total_pct:.2f}%)\n"
             f"🕑 Duration: {dur_str}"
         )


### PR DESCRIPTION
## Summary
- show price of TP1/TP2 actions
- include price in close notifications
- mention DCA price in telegram logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e0e10072083228fd4dc0656246239