### PR TITLE
Fix pnl fetching logic

### DIFF
--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -68,11 +68,9 @@ async def _fetch_closed_pnl(self, retries: int = 10) -> Optional[tuple[float, fl
 
             # rows are newest first
             if self.last_pnl_id is None:
-                row = rows[0]
-                self.last_pnl_id = row.get("id")
-                net_pnl = float(row["closedPnl"])
-                pnl_pct = net_pnl / float(row["cumEntryValue"]) * 100.0
-                return net_pnl, pnl_pct
+                self.last_pnl_id = rows[0].get("id")
+                await asyncio.sleep(1)
+                continue
 
             new_rows = []
             for r in rows:

--- a/tests/test_symbol_pnl.py
+++ b/tests/test_symbol_pnl.py
@@ -88,3 +88,72 @@ def test_multiple_tp1_pnl_accumulates(monkeypatch):
     asyncio.run(engine._handle_tp1(110))
     assert engine.risk.realized_pnl == pytest.approx(1.8)
     assert engine.last_pnl_id == "4"
+
+
+def test_fetch_closed_pnl_waits_for_new_entry(monkeypatch):
+    trading = types.SimpleNamespace(
+        leverage=1,
+        enable_hedging=False,
+        candle_interval_sec=1,
+        rsi_period=14,
+        adx_period=14,
+        tp1_close_ratio=0.5,
+        tp2_close_ratio=0.5,
+        min_profit_to_be=0.0,
+    )
+    entry_score = types.SimpleNamespace(symbol_weights={}, weights={}, threshold_k=1.0, symbol_threshold_k={})
+    settings_stub = types.SimpleNamespace(
+        bybit=types.SimpleNamespace(api_key="", api_secret="", testnet=False, demo=False, place_orders=False, channel_type="linear"),
+        trading=trading,
+        risk=types.SimpleNamespace(max_open_positions=0),
+        telegram=None,
+        entry_score=entry_score,
+        multi_tf=types.SimpleNamespace(enable=False, intervals=[]),
+        symbol_params={},
+    )
+    monkeypatch.setitem(sys.modules, 'app.config', types.SimpleNamespace(settings=settings_stub, SymbolParams=types.SimpleNamespace))
+
+    class DummyClient:
+        def __init__(self, symbol, *a, **k):
+            self.symbol = symbol
+            self.place_orders = False
+            self.http = types.SimpleNamespace(
+                get_positions=lambda category, symbol: {"result": {"list": [{}]}},
+                get_open_orders=lambda category, symbol: {"result": {"list": []}},
+            )
+        def set_leverage(self, *a, **k):
+            pass
+
+    monkeypatch.setitem(sys.modules, 'app.exchange', types.SimpleNamespace(BybitClient=DummyClient))
+
+    import app.symbol_engine as se
+    importlib.reload(se)
+    se.settings = settings_stub
+
+    engine = se.SymbolEngine("BTCUSDT")
+    engine.precision.step = lambda http, symbol: 0.1
+    engine.last_pnl_id = None
+
+    calls = 0
+    def fake_closed_pnl(category="linear", symbol="", limit=10):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return {"result": {"list": [
+                {"id": "1", "closedPnl": "0.2", "cumEntryValue": "100"},
+            ]}}
+        return {"result": {"list": [
+            {"id": "2", "closedPnl": "0.3", "cumEntryValue": "100"},
+            {"id": "1", "closedPnl": "0.2", "cumEntryValue": "100"},
+        ]}}
+
+    engine.client.http.get_closed_pnl = fake_closed_pnl
+
+    async def instant_sleep(_=0):
+        pass
+
+    monkeypatch.setattr(se.asyncio, "sleep", instant_sleep)
+
+    pnl = asyncio.run(se._fetch_closed_pnl(engine, retries=3))
+    assert pnl == (0.3, 0.3)
+    assert engine.last_pnl_id == "2"


### PR DESCRIPTION
## Summary
- handle cases where last pnl id is missing when fetching pnl
- ensure `_fetch_closed_pnl` waits for new entry
- test waiting for a new pnl entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e28a6d9548322929c9999ed37bfc3