### PR TITLE
Fix closed PnL parsing

### DIFF
--- a/app/symbol_engine.py
+++ b/app/symbol_engine.py
@@ -68,13 +68,14 @@ async def _fetch_closed_pnl(self, retries: int = 10) -> Optional[tuple[float, fl
 
             # rows are newest first
             if self.last_pnl_id is None:
-                self.last_pnl_id = rows[0].get("id")
+                first_id = rows[0].get("execId") or rows[0].get("id")
+                self.last_pnl_id = first_id
                 await asyncio.sleep(1)
                 continue
 
             new_rows = []
             for r in rows:
-                rid = r.get("id")
+                rid = r.get("execId") or r.get("id")
                 if rid == self.last_pnl_id:
                     break
                 new_rows.append(r)
@@ -83,7 +84,7 @@ async def _fetch_closed_pnl(self, retries: int = 10) -> Optional[tuple[float, fl
                 await asyncio.sleep(1)
                 continue
 
-            self.last_pnl_id = new_rows[0].get("id")
+            self.last_pnl_id = new_rows[0].get("execId") or new_rows[0].get("id")
             net = sum(float(r["closedPnl"]) for r in new_rows)
             entry = sum(float(r["cumEntryValue"]) for r in new_rows)
             pnl_pct = net / entry * 100.0 if entry else 0.0

--- a/tests/test_symbol_pnl.py
+++ b/tests/test_symbol_pnl.py
@@ -64,15 +64,15 @@ def test_multiple_tp1_pnl_accumulates(monkeypatch):
         calls += 1
         if calls == 1:
             return {"result": {"list": [
-                {"id": "3", "closedPnl": "1.0", "cumEntryValue": "100"},
-                {"id": "2", "closedPnl": "0.5", "cumEntryValue": "100"},
-                {"id": "1", "closedPnl": "0", "cumEntryValue": "100"},
+                {"execId": "3", "closedPnl": "1.0", "cumEntryValue": "100"},
+                {"execId": "2", "closedPnl": "0.5", "cumEntryValue": "100"},
+                {"execId": "1", "closedPnl": "0", "cumEntryValue": "100"},
             ]}}
         elif calls == 2:
             return {"result": {"list": [
-                {"id": "4", "closedPnl": "0.3", "cumEntryValue": "100"},
-                {"id": "3", "closedPnl": "1.0", "cumEntryValue": "100"},
-                {"id": "2", "closedPnl": "0.5", "cumEntryValue": "100"},
+                {"execId": "4", "closedPnl": "0.3", "cumEntryValue": "100"},
+                {"execId": "3", "closedPnl": "1.0", "cumEntryValue": "100"},
+                {"execId": "2", "closedPnl": "0.5", "cumEntryValue": "100"},
             ]}}
         return {"result": {"list": []}}
 
@@ -140,11 +140,11 @@ def test_fetch_closed_pnl_waits_for_new_entry(monkeypatch):
         calls += 1
         if calls == 1:
             return {"result": {"list": [
-                {"id": "1", "closedPnl": "0.2", "cumEntryValue": "100"},
+                {"execId": "1", "closedPnl": "0.2", "cumEntryValue": "100"},
             ]}}
         return {"result": {"list": [
-            {"id": "2", "closedPnl": "0.3", "cumEntryValue": "100"},
-            {"id": "1", "closedPnl": "0.2", "cumEntryValue": "100"},
+            {"execId": "2", "closedPnl": "0.3", "cumEntryValue": "100"},
+            {"execId": "1", "closedPnl": "0.2", "cumEntryValue": "100"},
         ]}}
 
     engine.client.http.get_closed_pnl = fake_closed_pnl


### PR DESCRIPTION
## Summary
- handle new `execId` field when reading closed PnL
- update PnL tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845808c5b3083229be7a5be2ed3a0de